### PR TITLE
Install required libraries into prefix

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -2,7 +2,6 @@
 
 set -ex
 
-ROOT=$(pwd)
 VERSION=$1
 
 pat='(^[0-9]+\.[0-9]+)'
@@ -17,19 +16,31 @@ echo "ce-build-revision:${REVISION}"
 echo "ce-build-output:${OUTPUT}"
 
 PREFIX_DIR=/opt/compiler-explorer/vala-${VERSION}
+mkdir -p "${PREFIX_DIR}"
+
+# "install" libraries and development headers required by the compiler to the prefix
+apt-get update && apt-get download libglib2.0-0 libglib2.0-dev libpcre3 libpcre3-dev
+find . -type f -name "*.deb" -exec dpkg-deb -x {} "${PREFIX_DIR}" \;
+
+# Strip the /usr prefix from the installed directory structure
+cp -R "${PREFIX_DIR}/usr/"* "${PREFIX_DIR}"
+rm -rf "${PREFIX_DIR:?}/usr"
+
+# Patch the prefix in the installed pkgconfig files
+find . "${PREFIX_DIR}" -type f -name "*.pc" -exec sed -i "s~prefix=/usr~prefix=${PREFIX_DIR}~g" {} \;
 
 curl -sL "https://download.gnome.org/sources/vala/${SHORT_VERSION}/vala-${VERSION}.tar.xz" | tar Jxf -
 pushd "vala-${VERSION}"
-./configure "--prefix=${PREFIX_DIR}"
+
+# We can build without the doc generator to save a bit of space and time
+./configure --disable-valadoc "--prefix=${PREFIX_DIR}"
 
 make "-j$(nproc)"
 make install
 popd
 
-# Copy dependent libraries, but not libdl, libc or libpthread. This isn't ideal..
-cp $(ldd "${PREFIX_DIR}/bin/vala" | grep -E  '=> (/usr/)?/lib' | grep -Ev 'lib(pthread|c|dl).so' | awk '{print $3}') "${PREFIX_DIR}/lib/"
 # patchelf claims to run on multiple files *but* if it fails on any one it silently stops and doesn't process anything else...
-find "${PREFIX_DIR}" -type f -perm /u+x -exec patchelf --set-rpath '$ORIGIN/../lib:$ORIGIN/../lib/vala-'"${SHORT_VERSION}" {} \;
+find "${PREFIX_DIR}" -type f -perm /u+x -exec patchelf --set-rpath '$ORIGIN/../lib:$ORIGIN/../lib/x86_64-linux-gnu/:$ORIGIN/../lib/vala-'"${SHORT_VERSION}" {} \;
 
 # strip executables
 find "${PREFIX_DIR}" -type f -perm /u+x -exec strip -d {} \;


### PR DESCRIPTION
This goes some way towards resolving https://github.com/compiler-explorer/compiler-explorer/issues/4958

We download and extract the deb packages for `libglib` and `libpcre` into the prefix, along with their development headers etc. Then patch their `pkgconfig` files to match the `/opt/compiler-explorer` prefix.

This should remove the need to copy libraries found with `ldd` as I think this covers the ones that would be missing from the host.

I've done some tests in a super minimal container without these libraries and this appears to work, but I'm not sure if there's a better way to test this against something more representative of the real infrastructure.

I'll need to do some work in the `compiler-explorer` repo to set the `PKG_CONFIG_PATH` environment variable into the relevant paths in the prefix when building on the live site. Expect a PR shortly!